### PR TITLE
Require face-remap.

### DIFF
--- a/centered-window-mode.el
+++ b/centered-window-mode.el
@@ -32,6 +32,8 @@
 ;;
 ;;; Code:
 
+(require 'face-remap)
+
 (defvar fringe-background nil "The background color used for the fringe")
 
 (defun cwm/setup ()


### PR DESCRIPTION
Hi!

Starting Emacs with the -q option and running `centered-window-mode` led to an error every time I opened a buffer (including the minibuffer):

```
cwm/center: Symbol's function definition is void: text-scale-mode
```

I'm running Emacs 24.5 on OS X.

Requiring face-remap should fix it.