### PR TITLE
Byte compiler warnings

### DIFF
--- a/centered-window-mode.el
+++ b/centered-window-mode.el
@@ -93,7 +93,8 @@ mode won't activate in that buffer."
 (defcustom centered-window-mode-hooks
   nil
   "Hooks to run everytime the text is centered (be careful)."
-  :group 'centered-window-mode)
+  :group 'centered-window-mode
+  :type 'hook)
 
 (defadvice load-theme (after cwm-set-faces-on-load-theme activate)
   "Change the default fringe background whenever the theme changes."
@@ -146,15 +147,13 @@ by this function."
   right-width)
 
 (defun cwm-center-window-instructions (instructions)
-  (let* ((window (cwm-centering-instructions-window instructions))
-         (frame (window-frame window)))
+  (let* ((window (cwm-centering-instructions-window instructions)))
     (set-window-fringes window
                         (cwm-centering-instructions-left-width instructions)
                         (cwm-centering-instructions-right-width instructions))))
 
 (defun cwm-centering-instructions (window)
-  (let ((buffer (window-buffer window))
-        (widths (cwm-calculate-appropriate-fringe-widths window)))
+  (let ((widths (cwm-calculate-appropriate-fringe-widths window)))
     (make-cwm-centering-instructions
      :window window
      :left-width (car widths)

--- a/centered-window-mode.el
+++ b/centered-window-mode.el
@@ -183,8 +183,7 @@ by this function."
   :init-value nil
   :global t
   :lighter cwm-lighter
-  (if centered-window-mode (cwm-turn-on) (cwm-turn-off))
-  )
+  (if centered-window-mode (cwm-turn-on) (cwm-turn-off)))
 
 (provide 'centered-window-mode)
 ;;; centered-window-mode.el ends here


### PR DESCRIPTION
Fix some [byte-compiler](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html) warnings.