### PR TITLE
Center window upon frame-size change

### DIFF
--- a/centered-window.el
+++ b/centered-window.el
@@ -169,6 +169,7 @@ by this function."
    `(fringe ((t (:background ,(face-attribute 'default :background)))))))
 
 (defun cwm-turn-on ()
+  (add-hook 'window-configuration-change-hook #'cwm-center-windows)
   (add-hook 'window-size-change-functions #'cwm-center-windows-frame)
   (cwm-center-windows)
   (when cwm-use-vertical-padding
@@ -176,6 +177,7 @@ by this function."
   (cwm-bind-fringe-mouse-events))
 
 (defun cwm-turn-off ()
+  (remove-hook 'window-configuration-change-hook #'cwm-center-windows)
   (remove-hook 'window-size-change-functions #'cwm-center-windows-frame)
   (cwm-center-windows)
   (set-frame-parameter nil 'internal-border-width 0)

--- a/centered-window.el
+++ b/centered-window.el
@@ -169,7 +169,6 @@ by this function."
    `(fringe ((t (:background ,(face-attribute 'default :background)))))))
 
 (defun cwm-turn-on ()
-  (add-hook 'window-configuration-change-hook #'cwm-center-windows)
   (add-hook 'window-size-change-functions #'cwm-center-windows-frame)
   (cwm-center-windows)
   (when cwm-use-vertical-padding
@@ -177,7 +176,6 @@ by this function."
   (cwm-bind-fringe-mouse-events))
 
 (defun cwm-turn-off ()
-  (remove-hook 'window-configuration-change-hook #'cwm-center-windows)
   (remove-hook 'window-size-change-functions #'cwm-center-windows-frame)
   (cwm-center-windows)
   (set-frame-parameter nil 'internal-border-width 0)

--- a/centered-window.el
+++ b/centered-window.el
@@ -170,6 +170,7 @@ by this function."
 
 (defun cwm-turn-on ()
   (add-hook 'window-configuration-change-hook #'cwm-center-windows)
+  (add-hook 'window-size-change-functions #'cwm-center-windows-frame)
   (cwm-center-windows)
   (when cwm-use-vertical-padding
     (set-frame-parameter nil 'internal-border-width cwm-frame-internal-border))
@@ -177,9 +178,14 @@ by this function."
 
 (defun cwm-turn-off ()
   (remove-hook 'window-configuration-change-hook #'cwm-center-windows)
+  (remove-hook 'window-size-change-functions #'cwm-center-windows-frame)
   (cwm-center-windows)
   (set-frame-parameter nil 'internal-border-width 0)
   (cwm-unbind-fringe-mouse-events))
+
+(defun cwm-center-windows-frame (frame)
+  (when (frame-size-changed-p frame)
+    (cwm-center-windows)))
 
 (defun cwm-center-windows ()
   (let ((windows (window-list nil :exclude-minibuffer)))


### PR DESCRIPTION
Fixes the issue in #37 by adding a hook to window-size-change-functions.