### PR TITLE
Fix hard coded frame border, window fringe restoration process

### DIFF
--- a/centered-window.el
+++ b/centered-window.el
@@ -180,7 +180,11 @@ by this function."
   (remove-hook 'window-configuration-change-hook #'cwm-center-windows)
   (remove-hook 'window-size-change-functions #'cwm-center-windows-frame)
   (cwm-center-windows)
-  (set-frame-parameter nil 'internal-border-width 0)
+  (set-frame-parameter
+   nil
+   'internal-border-width
+   (or (alist-get 'internal-border-width default-frame-alist)
+       0))
   (cwm-unbind-fringe-mouse-events))
 
 (defun cwm-center-windows-frame (frame)
@@ -217,17 +221,17 @@ by this function."
          (pixel (frame-char-width (window-frame window)))
          (window-width (window-total-width window))
          (n  (if mode-active-p
-               (max
-                (/ (- window-width cwm-centered-window-width)
-                   2)
-                (if cwm-incremental-padding
-                    (/ (* window-width cwm-incremental-padding-%)
-                       100)
-                  0))
-               0))
+                 (max
+                  (/ (- window-width cwm-centered-window-width)
+                     2)
+                  (if cwm-incremental-padding
+                      (/ (* window-width cwm-incremental-padding-%)
+                         100)
+                    0))
+               nil))
          (ratio (/ (* n cwm-left-fringe-ratio) 100))
-         (left-width (* pixel (if (> n 0) (+ n ratio) n)))
-         (right-width (* pixel (if (> n 0) (- n ratio) n))))
+         (left-width (* pixel (if (and n (> n 0)) (+ n ratio) n)))
+         (right-width (* pixel (if (and n (> n 0)) (- n ratio) n))))
     `(,left-width . ,right-width)))
 
 (defun cwm-toggle-bind-fringe-mouse-events (&optional bind direction-command-alist)

--- a/centered-window.el
+++ b/centered-window.el
@@ -221,17 +221,17 @@ by this function."
          (pixel (frame-char-width (window-frame window)))
          (window-width (window-total-width window))
          (n  (if mode-active-p
-                 (max
-                  (/ (- window-width cwm-centered-window-width)
-                     2)
-                  (if cwm-incremental-padding
-                      (/ (* window-width cwm-incremental-padding-%)
-                         100)
-                    0))
-               nil))
+               (max
+                (/ (- window-width cwm-centered-window-width)
+                   2)
+                (if cwm-incremental-padding
+                    (/ (* window-width cwm-incremental-padding-%)
+                       100)
+                  0))
+               0))
          (ratio (/ (* n cwm-left-fringe-ratio) 100))
-         (left-width (* pixel (if (and n (> n 0)) (+ n ratio) n)))
-         (right-width (* pixel (if (and n (> n 0)) (- n ratio) n))))
+         (left-width (and mode-active-p (* pixel (if (> n 0) (+ n ratio) n))))
+         (right-width (and mode-active-p (* pixel (if (> n 0) (- n ratio) n)))))
     `(,left-width . ,right-width)))
 
 (defun cwm-toggle-bind-fringe-mouse-events (&optional bind direction-command-alist)


### PR DESCRIPTION
Internal border is assumed to be 0 by default in this package, but some configuration preludes uses different values for aesthetic purpose. 

Note that this pull request isn't bullet proof; not save the value before `cwm` mode on, and restore it on deactivation, just restore default value. 

Also, for window fringes, went radically, preferring `nil` for restoration, which revert to default value, as described in the documentation of `set-window-fringes`. 